### PR TITLE
Remove cachedNow field from PgPool (unnecessary field, release uses M…

### DIFF
--- a/async_postgres/pg_pool.nim
+++ b/async_postgres/pg_pool.nim
@@ -118,8 +118,6 @@ type
     waiterCount: int ## Number of non-cancelled waiters
     closed: bool
     maintenanceTask: Future[void]
-    cachedNow: Moment
-      ## Updated on acquire(); reused by release() to avoid extra syscalls
     metrics: PoolMetrics
     pendingOps: Deque[PendingPoolOp] ## Queue for implicit pipeline batching
     dispatchScheduled: bool ## Whether a dispatch callback is pending
@@ -611,7 +609,7 @@ proc newPool*(config: PoolConfig): Future[PgPool] {.async.} =
   )
 
   try:
-    pool.cachedNow = Moment.now()
+    let now = Moment.now()
     # Open all `minSize` connections concurrently. `allFutures` waits for
     # every connect to settle (success or failure) without short-circuiting,
     # so a failure in one does not abandon the others mid-handshake — the
@@ -634,7 +632,7 @@ proc newPool*(config: PoolConfig): Future[PgPool] {.async.} =
         let conn = f.read()
         conn.ownerPool = pool
         pool.metrics.createCount.inc
-        pool.idle.addLast(PooledConn(conn: conn, lastUsedAt: pool.cachedNow))
+        pool.idle.addLast(PooledConn(conn: conn, lastUsedAt: now))
     if firstErr != nil:
       raise firstErr
   except CatchableError as e:
@@ -824,8 +822,8 @@ proc acquireImpl(pool: PgPool): Future[AcquireResult] {.async.} =
   if pool.closed:
     raise newException(PgPoolError, "Pool is closed")
 
-  pool.cachedNow = Moment.now()
-  let acquireStart = pool.cachedNow
+  let now = Moment.now()
+  let acquireStart = now
 
   # `acquireTimeout` is a deadline for the whole acquire: idle health-check
   # pings, a caller-driven connect, and the final waiter wait all draw from
@@ -860,7 +858,7 @@ proc acquireImpl(pool: PgPool): Future[AcquireResult] {.async.} =
         await pool.tracedClose(pc.conn)
         continue
       if pool.config.maxLifetime > ZeroDuration and
-          pool.cachedNow - pc.conn.createdAt > pool.config.maxLifetime:
+          now - pc.conn.createdAt > pool.config.maxLifetime:
         pool.metrics.closeCount.inc
         await pool.tracedClose(pc.conn)
         continue
@@ -873,7 +871,7 @@ proc acquireImpl(pool: PgPool): Future[AcquireResult] {.async.} =
           pool.config.tlsHealthCheckTimeout
         else:
           pool.config.healthCheckTimeout
-      if idleThreshold > ZeroDuration and pool.cachedNow - pc.lastUsedAt > idleThreshold:
+      if idleThreshold > ZeroDuration and now - pc.lastUsedAt > idleThreshold:
         var pingBudget = pool.config.pingTimeout
         if hasDeadline:
           let rem = remainingBudget()

--- a/tests/test_pool.nim
+++ b/tests/test_pool.nim
@@ -470,18 +470,15 @@ suite "Pool release":
     check pool.active == 0
     check pool.idle.len == 0
 
-  test "release stamps lastUsedAt with the return time, not stale cachedNow":
+  test "release stamps lastUsedAt with the return time, not a stale acquire-time timestamp":
     let pool = makePool()
     pool.active = 1
-    let staleNow = Moment.now() - minutes(30)
-    pool.cachedNow = staleNow
     let beforeRelease = Moment.now()
     let conn = mockConn()
     pool.release(conn)
     check pool.idle.len == 1
     check pool.idle[0].conn == conn
     check pool.idle[0].lastUsedAt >= beforeRelease
-    check pool.idle[0].lastUsedAt > staleNow
 
   test "release discards connection in transaction":
     let pool = makePool()
@@ -1768,11 +1765,9 @@ when hasChronos:
         pool.config.idleTimeout = milliseconds(200)
         pool.config.maintenanceInterval = milliseconds(20)
 
-        # Emulate a long borrow: `cachedNow` froze at acquire time, far older
-        # than idleTimeout. With a correct release, `lastUsedAt` is stamped at
-        # the actual return time, so the just-returned conn is well within the
-        # idle window and must not be reaped.
-        pool.cachedNow = Moment.now() - seconds(10)
+        # Emulate a long borrow: release must stamp `lastUsedAt` at the actual
+        # return time, so the just-returned conn is well within the idle window
+        # and must not be reaped.
         pool.active = 1
         let conn = mockConn()
         pool.release(conn)
@@ -1782,7 +1777,7 @@ when hasChronos:
         await sleepAsync(milliseconds(60))
 
         # idleTimeout (200ms) has not elapsed since the real return time, so the
-        # conn survives. The stale cachedNow (10s ago) would have evicted it.
+        # conn survives. A stale timestamp would have evicted it.
         doAssert pool.idle.len == 1
 
         pool.closed = true


### PR DESCRIPTION
…oment.now() directly)