### PR TITLE
fix: guard encode-side of timetz utcOffset and varbit against invalid…

### DIFF
--- a/async_postgres/pg_types/encoding.nim
+++ b/async_postgres/pg_types/encoding.nim
@@ -509,6 +509,12 @@ template writeTimeAt(buf: var openArray[byte], pos: int, val: PgTime) =
 template writeTimeTzAt(buf: var openArray[byte], pos: int, val: PgTimeTz) =
   block:
     let t = val
+    # Negating int32.low overflows int32 (uncatchable OverflowDefect). Mirrors
+    # the decoder's guard in decodeBinaryTimeTz.
+    if t.utcOffset == int32.low:
+      raise newException(
+        PgTypeError, "Invalid PgTimeTz: utcOffset out of range " & $t.utcOffset
+      )
     buf.writeBE64(pos, pgTimeFieldsMicros(t.hour, t.minute, t.second, t.microsecond))
     buf.writeBE32(pos + 8, int32(-t.utcOffset)) # PostgreSQL stores offset negated
 
@@ -816,6 +822,19 @@ proc toPgBinaryParam*(v: PgXml): PgParam =
 
 proc toPgBinaryParam*(v: PgBit): PgParam =
   ## Binary format: 4-byte bit count (big-endian) + packed bit data.
+  # Symmetric with the decoder guards in accessors.nim (getBit / bit array).
+  if v.nbits < 0:
+    raise newException(PgTypeError, "Invalid PgBit: negative nbits " & $v.nbits)
+  if v.nbits > PgBitMaxBits:
+    raise newException(
+      PgTypeError,
+      "Invalid PgBit: nbits " & $v.nbits & " exceeds limit (" & $PgBitMaxBits & ")",
+    )
+  if (int64(v.nbits) + 7) div 8 != int64(v.data.len):
+    raise newException(
+      PgTypeError,
+      "Invalid PgBit: nbits=" & $v.nbits & " inconsistent with data.len=" & $v.data.len,
+    )
   var data = newSeq[byte](4 + v.data.len)
   data.writeBE32(0, v.nbits)
   for i in 0 ..< v.data.len:

--- a/tests/test_types.nim
+++ b/tests/test_types.nim
@@ -847,6 +847,12 @@ suite "PgTimeTz":
     let row = @[none(seq[byte])]
     check row.getTimeTzOpt(0).isNone
 
+  test "toPgBinaryParam PgTimeTz rejects int32.low utcOffset":
+    # Negating int32.low would overflow int32 in the encoder.
+    let t = PgTimeTz(hour: 10, minute: 0, second: 0, utcOffset: int32.low)
+    expect PgTypeError:
+      discard toPgBinaryParam(t)
+
 suite "date parameter encoding":
   test "toPgDateParam OID and format":
     let dt = dateTime(2024, mJan, 15, 0, 0, 0, 0, utc())
@@ -6342,6 +6348,26 @@ suite "PgBit":
     # nbits = 3 in big-endian
     check data[0 .. 3] == @[0'u8, 0, 0, 3]
     check data[4] == 0b10100000'u8
+
+  test "toPgBinaryParam PgBit rejects negative nbits":
+    let b = PgBit(nbits: -1, data: @[0'u8])
+    expect PgTypeError:
+      discard toPgBinaryParam(b)
+
+  test "toPgBinaryParam PgBit rejects nbits above limit":
+    let b = PgBit(nbits: PgBitMaxBits + 1, data: @[])
+    expect PgTypeError:
+      discard toPgBinaryParam(b)
+
+  test "toPgBinaryParam PgBit rejects nbits/data.len mismatch":
+    # nbits=8 requires exactly 1 packed byte; supplying 2 must be rejected.
+    let b = PgBit(nbits: 8, data: @[0'u8, 0'u8])
+    expect PgTypeError:
+      discard toPgBinaryParam(b)
+    # nbits=3 requires 1 byte; supplying 0 must also be rejected.
+    let b2 = PgBit(nbits: 3, data: @[])
+    expect PgTypeError:
+      discard toPgBinaryParam(b2)
 
   test "getBit text format":
     let data = toBytes("10110011")


### PR DESCRIPTION
… values